### PR TITLE
Change FILE_PREFIX so paths are relative

### DIFF
--- a/simple-testing-server.py
+++ b/simple-testing-server.py
@@ -5,7 +5,7 @@ import cgi
 
 
 PORT = 8003
-FILE_PREFIX = ""
+FILE_PREFIX = "."
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
This changes the FILE_PREFIX to "." so whenever open() is called, the path given
is relative to the current script instead of absolute.